### PR TITLE
Repository를 상속한 v4버전 구현.

### DIFF
--- a/src/main/java/com/example/blogcoderepositorydi/repository/v1/V1StudentRepository.java
+++ b/src/main/java/com/example/blogcoderepositorydi/repository/v1/V1StudentRepository.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Repository;
  *
  *
  * - JpaRepository를 extends 합니다.
- *     - SimpleJpaRepository를 target으로 하는 proxy가 생성됩니다.
+ *     - JpaRepository 인터페이스를 target으로 하는 proxy가 생성됩니다.(정확히는 Repository가 아닐까 추측)
  *     - 즉 bean DI에 문제가 없어 정상 작동 합니다.
  * </pre>
  */

--- a/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentJooqRepository.java
+++ b/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentJooqRepository.java
@@ -1,0 +1,8 @@
+package com.example.blogcoderepositorydi.repository.v4;
+
+import com.example.blogcoderepositorydi.entity.Student;
+
+interface V4StudentJooqRepository {
+
+	Student getByNameAndAge(String name, Integer age);
+}

--- a/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentJooqRepositoryImpl.java
+++ b/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentJooqRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.example.blogcoderepositorydi.repository.v4;
+
+import com.example.blogcoderepositorydi.entity.Student;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+class V4StudentJooqRepositoryImpl implements V4StudentJooqRepository {
+
+	@Override
+	public Student getByNameAndAge(final String name, final Integer age) {
+		return Student.of("학생 jooq", age, "강남구");
+	}
+}

--- a/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentQuerydslRepository.java
+++ b/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentQuerydslRepository.java
@@ -1,0 +1,8 @@
+package com.example.blogcoderepositorydi.repository.v4;
+
+import com.example.blogcoderepositorydi.entity.Student;
+
+interface V4StudentQuerydslRepository {
+
+	Student getByAgeAndAdress(Integer age, String adress);
+}

--- a/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentQuerydslRepositoryImpl.java
+++ b/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentQuerydslRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.example.blogcoderepositorydi.repository.v4;
+
+import com.example.blogcoderepositorydi.entity.Student;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+class V4StudentQuerydslRepositoryImpl implements V4StudentQuerydslRepository {
+
+	@Override
+	public Student getByAgeAndAdress(final Integer age, final String adress) {
+		return Student.of("학생 querydsl", age, "강남구");
+	}
+}

--- a/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentRepository.java
+++ b/src/main/java/com/example/blogcoderepositorydi/repository/v4/V4StudentRepository.java
@@ -1,0 +1,18 @@
+package com.example.blogcoderepositorydi.repository.v4;
+
+import com.example.blogcoderepositorydi.entity.Student;
+import org.springframework.data.repository.Repository;
+
+/**
+ * <pre>
+ * v4
+ *
+ * v3의 문제는 V3StudentQuerydslRepository, V3StudentJooqRepository를 중간에서 연결해주는 V3StudentRepository를 개발자가 직접 만들어야 하는것이라고 생각합니다.
+ * 아무런 추상메서드가 선언되어있지 않은 Repository를 Proxy의 타겟으로 두어 개발자의 편의성을 높일 수 있다고 생각합니다.
+ */
+public interface V4StudentRepository extends
+//		Repository, // NOTE: Generic 을 선언하지 않으면 오류가 발생합니다. 이 오류로 JpaRepositoryFactory가 @Repository빈을 생성하는 과정을 추적할 수 있습니다.
+		Repository<Student, Long>,
+		V4StudentQuerydslRepository,
+		V4StudentJooqRepository {
+}

--- a/src/test/java/com/example/blogcoderepositorydi/repository/v4/V4StudentRepositoryTest.java
+++ b/src/test/java/com/example/blogcoderepositorydi/repository/v4/V4StudentRepositoryTest.java
@@ -1,0 +1,20 @@
+package com.example.blogcoderepositorydi.repository.v4;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class V4StudentRepositoryTest {
+
+	@Autowired
+	private V4StudentRepository v4StudentRepository;
+
+	@Test
+	void get() {
+		assertThat(v4StudentRepository.getByNameAndAge("학생10", 20).getName()).isEqualTo("학생 jooq");
+		assertThat(v4StudentRepository.getByAgeAndAdress(20, "서초구").getName()).isEqualTo("학생 querydsl");
+	}
+}


### PR DESCRIPTION
어제 구두로만 추측성으로 전달드렸는데, 소스판을 깔아주셔서 적용해봤습니다.
감사합니다. 
수고하셨습니다.

---

Repository를 적용한 v4를 사용함으로서
연결하는 클래스를 개발자가 작성하지않으면서 (스프링에게 위임시킬 수 있고)
원하지않았던 `JpaRepository`, `PagingAndSortingRepository` 등의 추상메서드의 구현체들이 생기지 않아서 (사이즈가 안커져서)
일석이조의 효과를 얻을 수 있을 것 같습니다.
```java
package org.springframework.data.repository;

import org.springframework.stereotype.Indexed;

@Indexed
public interface Repository<T, ID> {

}
```